### PR TITLE
Azure Functions - Bindings register recommend latest version range for bundles

### DIFF
--- a/articles/azure-functions/functions-bindings-register.md
+++ b/articles/azure-functions/functions-bindings-register.md
@@ -47,14 +47,14 @@ The following table lists the currently available version ranges of the default 
 
 | Bundle version | Version in host.json | Included extensions |
 | --- | --- | --- |
+| 4.x | `[4.0.0, 5.0.0)` | See [extensions.json](https://github.com/Azure/azure-functions-extension-bundles/blob/main/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) used to generate the bundle. |
+| 3.x | `[3.3.0, 4.0.0)` | See [extensions.json](https://github.com/Azure/azure-functions-extension-bundles/blob/main-v3/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) used to generate the bundle. |
+| 2.x | `[2.*, 3.0.0)` | See [extensions.json](https://github.com/Azure/azure-functions-extension-bundles/blob/main-v2/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) used to generate the bundle. |
 | 1.x | `[1.*, 2.0.0)` | See [extensions.json](https://github.com/Azure/azure-functions-extension-bundles/blob/v1.x/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) used to generate the bundle. |
-| 2.x | `[2.*, 3.0.0)` | See [extensions.json](https://github.com/Azure/azure-functions-extension-bundles/blob/v2.x/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) used to generate the bundle. |
-| 3.x | `[3.3.0, 4.0.0)` | See [extensions.json](https://github.com/Azure/azure-functions-extension-bundles/blob/v3.x/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) used to generate the bundle. |
-| 4.x | `[4.0.0, 5.0.0)` | See [extensions.json](https://github.com/Azure/azure-functions-extension-bundles/blob/v4.x/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) used to generate the bundle. |
 
 
 > [!NOTE]
-> Even though host.json supports custom ranges for `version`, you should use a version range value from this table, such as  `[4.0.0, 5.0.0)`. For a complete list of extension bundle releases and extension versions in each release, see the [extension bundles release page](https://github.com/Azure/azure-functions-extension-bundles/releases). 
+> Even though host.json supports custom ranges for `version`, you should use a version range value from this table, such as  `[4.0.0, 5.0.0)`. To ensure optimal performance and access to the latest features, it is <b>recommended to use the latest version range</b>. For a complete list of extension bundle releases and extension versions in each release, see the [extension bundles release page](https://github.com/Azure/azure-functions-extension-bundles/releases).
 
 ## Explicitly install extensions
 


### PR DESCRIPTION
This pull request updates the documentation for Azure Functions extension bundles to improve clarity and ensure users are directed to the latest resources. The most important changes include reordering and updating the version range table and enhancing the recommendation for using the latest version range.

### Documentation updates:

* [`articles/azure-functions/functions-bindings-register.md`](diffhunk://#diff-e6de1097420912bae6c1a3bb964bf6f10d28cd879e4f106ea6e449344e7287bcR50-R57): Reordered and updated the version range table for extension bundles to align with the main branch structure and ensure accuracy.
* [`articles/azure-functions/functions-bindings-register.md`](diffhunk://#diff-e6de1097420912bae6c1a3bb964bf6f10d28cd879e4f106ea6e449344e7287bcR50-R57): Enhanced the note recommending the use of the latest version range for optimal performance and access to new features.

Resolves https://github.com/Azure/azure-functions-extension-bundles/issues/375

